### PR TITLE
Update sedump

### DIFF
--- a/sedump
+++ b/sedump
@@ -126,7 +126,7 @@ class SELinuxPolicy(setools.SELinuxPolicy):
 
                 # allow/dontaudit/auditallow/neverallow rules
                 if len(perms) > 1:
-                    rule_ += " {{ {0} }};".format(' '.join(perms))
+                    rule_ += " {{ {0} }};".format(' '.join(str(v) for v in perms))
                 else:
                     # convert to list since sets cannot be indexed
                     rule_ += " {0};".format(list(perms)[0])


### PR DESCRIPTION
join needs strings not ints, resulting in error:

TypeError: sequence item 0: expected string, int found